### PR TITLE
Mobile View (Unterschiedliche Formulare anhand von Breakpoints)

### DIFF
--- a/frontend/src/form/SubformDialog.tsx
+++ b/frontend/src/form/SubformDialog.tsx
@@ -1,0 +1,48 @@
+import { Formik, FormikBag, FormikConfig, FormikProps } from 'formik';
+import * as React from 'react';
+import Dialog from '@material-ui/core/Dialog/Dialog';
+import DialogContent from '@material-ui/core/DialogContent/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions/DialogActions';
+import Button from '@material-ui/core/Button/Button';
+import { LoadingSpinner } from '../layout/LoadingSpinner';
+import { Prompt } from 'react-router';
+import { HandleFormikSubmit } from '../types';
+
+interface DialogFormProps<T> {
+  title: string;
+  onSubmit: (values: T) => Promise<void>;
+  loading?: boolean;
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export class SubformDialog<Values = object, ExtraProps = {}> extends React.Component<
+  FormikConfig<Values> & ExtraProps & DialogFormProps<Values>
+> {
+  public handleSubmit: HandleFormikSubmit<Values> = async (values, formikBag) => {
+    await this.props.onSubmit(values);
+    formikBag.setSubmitting(false);
+  };
+
+  public handleClose = () => {
+    this.props.onClose();
+  };
+
+  public render() {
+    return this.props.loading ? (
+      <Dialog open={this.props.open} onClose={this.props.onClose}>
+        <LoadingSpinner />
+      </Dialog>
+    ) : (
+      <>
+        <Dialog open={this.props.open} onClose={this.handleClose}>
+          <DialogContent>{this.props.children}</DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleClose}>Schliessen</Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  }
+}

--- a/frontend/src/layout/OverviewTable.tsx
+++ b/frontend/src/layout/OverviewTable.tsx
@@ -12,6 +12,7 @@ import createStyles from '@material-ui/core/styles/createStyles';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import Checkbox from '@material-ui/core/Checkbox/Checkbox';
 import { DimeTableCell } from './DimeTableCell';
+import classNames from 'classnames';
 
 const styles = createStyles({
   hideActions: {
@@ -23,6 +24,10 @@ const styles = createStyles({
         visibility: 'visible',
       },
     },
+  },
+  error: {
+    //TODO use bright red color from theme
+    backgroundColor: 'red',
   },
 });
 
@@ -70,6 +75,7 @@ interface TableProps<T> extends WithStyles<typeof styles> {
   data: Array<T>;
   onClickRow?: (e: T, index: number) => void;
   noSort?: boolean;
+  errorChecker?: (index: number) => boolean;
   selected?: number[];
   setSelected?: (e: T, state: boolean) => void;
 }
@@ -166,31 +172,34 @@ class OverviewTableInner<T extends { id?: number }> extends React.Component<Tabl
           </TableRow>
         </TableHead>
         <TableBody>
-          {sortedData.map((row, index) => (
-            <TableRow
-              className={classes.hideActions}
-              hover
-              key={index}
-              onClick={this.handleRowClick(row, index)}
-              component={SafeClickableTableRow}
-            >
-              {this.props.selected && (
-                <DimeTableCell padding={'checkbox'}>
-                  <RowCheckbox row={row} />
-                </DimeTableCell>
-              )}
-              {columns.map(col => (
-                <DimeTableCell key={col.id} numeric={col.numeric}>
-                  {format(col, row)}
-                </DimeTableCell>
-              ))}
-              {this.props.renderActions && (
-                <DimeTableCell numeric>
-                  <span className={'actions'}>{this.props.renderActions(row)}</span>
-                </DimeTableCell>
-              )}
-            </TableRow>
-          ))}
+          {sortedData.map((row, index) => {
+            const hasErrors = this.props.errorChecker && this.props.errorChecker(index);
+            return (
+              <TableRow
+                className={classNames(classes.hideActions, { [classes.error]: hasErrors })}
+                hover
+                key={index}
+                onClick={this.handleRowClick(row, index)}
+                component={SafeClickableTableRow}
+              >
+                {this.props.selected && (
+                  <DimeTableCell padding={'checkbox'}>
+                    <RowCheckbox row={row} />
+                  </DimeTableCell>
+                )}
+                {columns.map(col => (
+                  <DimeTableCell key={col.id} numeric={col.numeric}>
+                    {format(col, row)}
+                  </DimeTableCell>
+                ))}
+                {this.props.renderActions && (
+                  <DimeTableCell numeric>
+                    <span className={'actions'}>{this.props.renderActions(row)}</span>
+                  </DimeTableCell>
+                )}
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     );

--- a/frontend/src/layout/SubformTable.tsx
+++ b/frontend/src/layout/SubformTable.tsx
@@ -1,0 +1,78 @@
+import { Column } from './Overview';
+import { OverviewTable } from './OverviewTable';
+import * as React from 'react';
+import { SubformDialog } from '../form/SubformDialog';
+import { FormikProps, getIn } from 'formik';
+
+interface Props<T> {
+  columns: Array<Column<T>>;
+  title: string;
+  renderForm: (index: number, name: (s: string) => string) => React.ReactNode;
+  defaultValues: object;
+  renderActions?: (e: T) => React.ReactNode;
+  name: string;
+  formikProps: FormikProps<any>;
+}
+
+export class SubformTable<T> extends React.Component<Props<T>> {
+  public state = {
+    editing: false,
+    editIndex: undefined,
+  };
+
+  public get values() {
+    return this.props.formikProps.values[this.props.name];
+  }
+
+  public errorChecker = (index: number) => {
+    const error = getIn(this.props.formikProps.errors, `${this.props.name}.${index}`);
+    console.log('Error for ', index, error);
+    return !!error;
+  };
+
+  public handleClick = async (entity: T, index: number) => {
+    this.setState({
+      editing: true,
+      editIndex: index,
+    });
+  };
+
+  public handleClose = () => {
+    this.setState({ editIndex: undefined });
+  };
+
+  public handleAdd = () => {
+    this.setState({ editing: true });
+  };
+
+  public handleSubmit = () => Promise.resolve();
+
+  public render() {
+    const name = (index: number) => (fieldName: string) => `${this.props.name}.${index}.${fieldName}`;
+
+    return (
+      <>
+        <OverviewTable
+          noSort
+          columns={this.props.columns}
+          data={this.values}
+          errorChecker={this.errorChecker}
+          onClickRow={this.handleClick}
+        />
+        {this.state.editIndex !== undefined && (
+          // maybe we could render those dialogs based on route, just as the full-page form views? does that make things easier?
+          // ...probably not on subforms
+          <SubformDialog
+            open
+            onClose={this.handleClose}
+            title={this.props.title}
+            initialValues={this.values[this.state.editIndex!] || this.props.defaultValues}
+            onSubmit={this.handleSubmit}
+          >
+            {this.props.renderForm(this.state.editIndex!, name(this.state.editIndex!))}
+          </SubformDialog>
+        )}
+      </>
+    );
+  }
+}

--- a/frontend/src/views/offers/OfferForm.tsx
+++ b/frontend/src/views/offers/OfferForm.tsx
@@ -31,6 +31,9 @@ import { RateGroupStore } from '../../stores/rateGroupStore';
 import { EmployeeStore } from '../../stores/employeeStore';
 import { RateUnitStore } from '../../stores/rateUnitStore';
 import { ServiceStore } from '../../stores/serviceStore';
+import withWidth from '@material-ui/core/withWidth/withWidth';
+import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
+import OfferPositionSubformDialogs from './OfferPositionSubformDialogs';
 
 export interface Props extends FormViewProps<Offer> {
   customerStore?: CustomerStore;
@@ -41,11 +44,13 @@ export interface Props extends FormViewProps<Offer> {
   rateGroupStore?: RateGroupStore;
   rateUnitStore?: RateUnitStore;
   serviceStore?: ServiceStore;
+  width?: Breakpoint;
 }
 
 @compose(
   inject('customerStore', 'employeeStore', 'offerStore', 'projectStore', 'rateGroupStore', 'rateUnitStore', 'serviceStore'),
-  observer
+  observer,
+  withWidth()
 )
 export default class OfferForm extends React.Component<Props> {
   // set rateGroup based on selected customer.
@@ -187,7 +192,11 @@ export default class OfferForm extends React.Component<Props> {
 
                   <Grid item xs={12}>
                     <DimePaper>
-                      <OfferPositionSubformInline formikProps={props} name={'positions'} disabled={locked} />
+                      {this.props.width === 'xl' || this.props.width === 'lg' ? (
+                        <OfferPositionSubformInline formikProps={props} name={'positions'} disabled={locked} />
+                      ) : (
+                        <OfferPositionSubformDialogs formikProps={props} name={'positions'} />
+                      )}
                     </DimePaper>
                   </Grid>
 

--- a/frontend/src/views/offers/OfferPositionSubformDialogs.tsx
+++ b/frontend/src/views/offers/OfferPositionSubformDialogs.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import { inject, observer } from 'mobx-react';
+import compose from '../../utilities/compose';
+import { MainStore } from '../../stores/mainStore';
+import TableToolbar from '../../layout/TableToolbar';
+import { Offer, OfferPosition } from '../../types';
+import { Field, FieldArray, FormikProps } from 'formik';
+
+import { ServiceSelector } from '../../form/entitySelector/ServiceSelector';
+import { SubformTable } from '../../layout/SubformTable';
+import { Column } from '../../layout/Overview';
+import { NumberField } from '../../form/fields/common';
+import { RateUnitSelector } from '../../form/entitySelector/RateUnitSelector';
+import PercentageField from '../../form/fields/PercentageField';
+import { RateUnitStore } from '../../stores/rateUnitStore';
+import { ServiceStore } from '../../stores/serviceStore';
+import { computed } from 'mobx';
+import CurrencyField from '../../form/fields/CurrencyField';
+import { Formatter } from '../../utilities/formatter';
+
+const template = {
+  amount: '',
+  order: 1,
+  price_per_rate: '',
+  rate_unit_id: '',
+  vat: 0.077, // this should probably be configurable somewhere; user settings?
+};
+
+export interface Props {
+  formatter?: Formatter;
+  formikProps: FormikProps<Offer>;
+  name: string;
+  serviceStore?: ServiceStore;
+  rateUnitStore?: RateUnitStore;
+}
+
+@compose(
+  inject('formatter', 'serviceStore', 'rateUnitStore'),
+  observer
+)
+export default class OfferPositionSubformDialogs extends React.Component<Props> {
+  @computed
+  public get columns(): Array<Column<OfferPosition>> {
+    const { serviceStore, rateUnitStore, formatter } = this.props;
+    return [
+      {
+        id: 'order',
+        numeric: false,
+        label: 'Reihenfolge',
+      },
+      {
+        id: 'service_id',
+        numeric: false,
+        label: 'Service',
+        format: ({ service_id }) => {
+          const service = serviceStore!.services.find(s => s.id === service_id);
+          return service ? service.name : service_id;
+        },
+      },
+      {
+        id: 'price_per_rate',
+        numeric: false,
+        label: 'Tarif',
+        format: p => formatter!.formatCurrency(p.price_per_rate),
+      },
+      {
+        id: 'rate_unit_id',
+        numeric: false,
+        label: 'Tariftyp',
+        format: ({ rate_unit_id }) => {
+          const id = rate_unit_id;
+          const rateUnit = rateUnitStore!.rateUnits.find(s => s.id === id);
+          return rateUnit ? rateUnit.effort_unit : id;
+        },
+      },
+      {
+        id: 'amount',
+        numeric: true,
+        label: 'Menge',
+      },
+      {
+        id: 'vat',
+        numeric: true,
+        label: 'MwSt',
+        format: ({ vat }) => (vat * 100).toFixed(2) + ' %',
+      },
+      {
+        id: 'total',
+        numeric: true,
+        label: 'Total',
+        format: p => formatter!.formatCurrency(p.amount * p.price_per_rate * (1 + p.vat)),
+      },
+    ];
+  }
+
+  public render() {
+    const { values } = this.props.formikProps;
+
+    return (
+      <FieldArray
+        name={this.props.name}
+        render={arrayHelpers => (
+          <>
+            <TableToolbar title={'Services'} numSelected={0} addAction={() => arrayHelpers.push(template)} />
+            <SubformTable
+              title={'Services'}
+              name={this.props.name}
+              formikProps={this.props.formikProps}
+              columns={this.columns}
+              defaultValues={template}
+              renderForm={(index, name) => {
+                const p = values.positions[index] as OfferPosition;
+                const total = p.amount * p.price_per_rate * (1 + p.vat);
+
+                return (
+                  <>
+                    <div>
+                      <Field component={NumberField} label={'Reihenfolge'} name={name('order')} />
+                    </div>
+                    <div>
+                      <Field component={ServiceSelector} label={'Service'} name={name('service_id')} />
+                    </div>
+                    <div>
+                      <Field component={CurrencyField} label="Tarif" name={name('price_per_rate')} />
+                    </div>
+                    <div>
+                      <Field disabled component={RateUnitSelector} label="Einheit" name={name('rate_unit_id')} />
+                    </div>
+                    <div>
+                      <Field component={NumberField} label="Menge" name={name('amount')} />
+                    </div>
+                    <div>
+                      <Field component={PercentageField} label="MwSt." name={name('vat')} />
+                    </div>
+                    <br />
+                    <div>Total: {this.props.formatter!.formatCurrency(total)}</div>
+                  </>
+                );
+              }}
+            />
+          </>
+        )}
+      />
+    );
+  }
+}

--- a/frontend/src/views/projects/ProjectForm.tsx
+++ b/frontend/src/views/projects/ProjectForm.tsx
@@ -33,6 +33,9 @@ import { ServiceStore } from '../../stores/serviceStore';
 import { CostgroupStore } from '../../stores/costgroupStore';
 import { ProjectCostgroupSubform } from './ProjectCostgroupSubform';
 import { ProjectBudgetTable } from './ProjectBudgetTable';
+import ProjectPositionSubformDialogs from './ProjectPositionSubformDialogs';
+import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
+import { withWidth } from '@material-ui/core';
 
 interface InfoFieldProps {
   value: string;
@@ -71,6 +74,7 @@ export interface Props extends FormViewProps<Project> {
   rateGroupStore?: RateGroupStore;
   rateUnitStore?: RateUnitStore;
   serviceStore?: ServiceStore;
+  width?: Breakpoint;
 }
 
 @compose(
@@ -85,7 +89,8 @@ export interface Props extends FormViewProps<Project> {
     'rateUnitStore',
     'serviceStore'
   ),
-  observer
+  observer,
+  withWidth()
 )
 export default class ProjectForm extends React.Component<Props> {
   // set rateGroup based on selected customer.
@@ -219,7 +224,11 @@ export default class ProjectForm extends React.Component<Props> {
 
               <Grid item xs={12}>
                 <DimePaper>
-                  <ProjectPositionSubformInline formikProps={props} name={'positions'} />
+                  {this.props.width === 'xl' || this.props.width === 'lg' ? (
+                    <ProjectPositionSubformInline formikProps={props} name={'positions'} />
+                  ) : (
+                    <ProjectPositionSubformDialogs formikProps={props} name={'positions'} />
+                  )}
                 </DimePaper>
               </Grid>
             </Grid>

--- a/frontend/src/views/projects/ProjectPositionSubformDialogs.tsx
+++ b/frontend/src/views/projects/ProjectPositionSubformDialogs.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { inject, observer } from 'mobx-react';
+import compose from '../../utilities/compose';
+import { MainStore } from '../../stores/mainStore';
+import TableToolbar from '../../layout/TableToolbar';
+import { Project, ProjectPosition } from '../../types';
+import { ErrorMessage, Field, FieldArray, FormikProps, getIn } from 'formik';
+
+import { ServiceSelector } from '../../form/entitySelector/ServiceSelector';
+import { SubformTable } from '../../layout/SubformTable';
+import { Column } from '../../layout/Overview';
+import { TextField } from '../../form/fields/common';
+import { RateUnitSelector } from '../../form/entitySelector/RateUnitSelector';
+import PercentageField from '../../form/fields/PercentageField';
+import { RateUnitStore } from '../../stores/rateUnitStore';
+import { ServiceStore } from '../../stores/serviceStore';
+import { computed } from 'mobx';
+import CurrencyField from '../../form/fields/CurrencyField';
+import { Formatter } from '../../utilities/formatter';
+
+const template = {
+  description: '',
+  service_id: '',
+  price_per_rate: 0,
+  rate_unit_id: '',
+  vat: 0.077, // this should probably be configurable somewhere; user settings?
+};
+
+export interface Props {
+  formatter?: Formatter;
+  formikProps: FormikProps<Project>;
+  name: string;
+  serviceStore?: ServiceStore;
+  rateUnitStore?: RateUnitStore;
+}
+
+@compose(
+  inject('formatter', 'serviceStore', 'rateUnitStore'),
+  observer
+)
+export default class ProjectPositionSubformDialogs extends React.Component<Props> {
+  @computed
+  public get columns(): Array<Column<ProjectPosition>> {
+    const { serviceStore, rateUnitStore, formatter } = this.props;
+    return [
+      {
+        id: 'service',
+        numeric: false,
+        label: 'Service',
+        format: ({ service_id }) => {
+          const service = serviceStore!.services.find(s => s.id === service_id);
+          return service ? service.name : service_id;
+        },
+      },
+      {
+        id: 'description',
+        label: 'Beschreibung',
+      },
+      {
+        id: 'price_per_rate',
+        numeric: true,
+        label: 'Tarif',
+        format: p => formatter!.formatCurrency(p.price_per_rate),
+      },
+      {
+        id: 'efforts_value_with_unit',
+        numeric: true,
+        label: 'Anzahl',
+      },
+    ];
+  }
+
+  public render() {
+    const { values } = this.props.formikProps;
+
+    return (
+      <FieldArray
+        name={this.props.name}
+        render={arrayHelpers => (
+          <>
+            <TableToolbar title={'Services'} numSelected={0} addAction={() => arrayHelpers.push(template)} />
+            <SubformTable
+              title={'Services'}
+              name={this.props.name}
+              formikProps={this.props.formikProps}
+              columns={this.columns}
+              defaultValues={template}
+              renderForm={(index, name) => {
+                const p = values.positions[index] as any;
+                const total = p.amount * p.price_per_rate * (1 + p.vat);
+
+                return (
+                  <>
+                    {/*TODO service should not be editable in existing entities; */}
+                    {/*in new entities, selecting it should prefill tarif, einheit, mwst - maybe use a wizard flow? */}
+                    <div>
+                      <Field component={ServiceSelector} label={'Service'} name={name('service_id')} />
+                    </div>
+                    <div>
+                      <Field component={TextField} label={'Beschreibung'} name={name('description')} />
+                    </div>
+                    <div>
+                      <Field component={CurrencyField} label="Tarif" name={name('price_per_rate')} />
+                    </div>
+                    <div>
+                      <Field disabled component={RateUnitSelector} label="Einheit" name={name('rate_unit_id')} />
+                    </div>
+                    <div>
+                      <Field component={PercentageField} label="MwSt." name={name('vat')} />
+                    </div>
+                  </>
+                );
+              }}
+            />
+          </>
+        )}
+      />
+    );
+  }
+}


### PR DESCRIPTION
Hier geht es um die Offer, Project, Invoice Formulare, insbesondere die Tabellarische Auflistung deren Positionen.

Wir haben mit verschiedenen Varianten dieser Tabellen herumgespielt. Herauskristallisiert haben sich:
* Eine Inline Tabelle, wie in der alten Implementierung von Dime
* Eine Tabelle, die beim Klick auf eine Zeile ein Subformular in einem Dialog öffnet. (Dies würde auf Mobile funktionieren, während die andere Lösung dort kaum bedienbar ist)

Andi Wolf bevorzugt die Lösung mit der Inline-Tabelle, zumal wohl kaum Offerten etc. auf dem Handy bearbeitet wärden. Längerfristig wäre es eine coole Lösung für kleinere Screens responsively die Dialog-View anzuzeigen.

Vorerst werden also die Inline-Tabellen implementiert. Dieser Pull-Request dient als Beispiel, wie die Responsive Variante in Zukunft umgesetzt werden kann; Sieh hier: https://github.com/stiftungswo/betterDime/pull/31/files#diff-459347bf25b9f189b9daf248db2b3a2dR195