### PR TITLE
exclude deleted projects and invoices from the list of projects with potential invoices

### DIFF
--- a/api/app/Http/Controllers/api/v1/ProjectController.php
+++ b/api/app/Http/Controllers/api/v1/ProjectController.php
@@ -236,12 +236,14 @@ from (
               inner join project_efforts pe on pp.id = pe.position_id
        where projects.chargeable = 1
        and projects.archived = 0
+       and projects.deleted_at is null
        group by projects.id
      ) last_effort
        left join (
   select projects.id, max(i.end) as last_invoice_date
   from projects
          left join invoices i on projects.id = i.project_id
+  where i.deleted_at is null
   group by projects.id
 ) last_invoice on last_effort.id = last_invoice.id
  where last_invoice_date < last_effort_date or last_invoice_date is null


### PR DESCRIPTION
Some projects with deleted invoices or projects who were themselves deleted were included in the list of projects with potential invoices. This is now fixed.