### PR TITLE
Fix #434

### DIFF
--- a/apir/app/services/pdfs/generators/mail_header_generator.rb
+++ b/apir/app/services/pdfs/generators/mail_header_generator.rb
@@ -135,10 +135,10 @@ module Pdfs
           @document.text @data.customer.department, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.department.present?
           @document.text (@data.customer.salutation || "") + " " + @data.customer.full_name, @default_text_settings.merge(size: 10, leading: 6)
           # use text_box to avoid line-wrapping long addresses
-          @document.text_box @data.address.street, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 10)
+          @document.text_box @data.address.street, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 12)
           @document.move_down 16
           @document.text @data.address.supplement, @default_text_settings.merge(size: 10, leading: 6) if @data.address.supplement.present?
-          @document.text_box @data.address.zip.to_s + " " + @data.address.city, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 10)
+          @document.text_box @data.address.zip.to_s + " " + @data.address.city, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 12)
         end
       end
     end

--- a/apir/app/services/pdfs/generators/mail_header_generator.rb
+++ b/apir/app/services/pdfs/generators/mail_header_generator.rb
@@ -134,11 +134,13 @@ module Pdfs
           @document.text @data.customer.company.name, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.company
           @document.text @data.customer.department, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.department
           @document.text (@data.customer.salutation || "") + " " + @data.customer.full_name, @default_text_settings.merge(size: 10, leading: 6)
-          @document.text @data.address.street, @default_text_settings.merge(size: 10, leading: 6)
+          # use text_box to avoid line-wrapping long addresses
+          @document.text_box @data.address.street, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 10)
+          @document.move_down(16)
           if @data.address.supplement && @data.address.supplement.length > 0
             @document.text @data.address.supplement, @default_text_settings.merge(size: 10, leading: 6)
           end
-          @document.text @data.address.zip.to_s + " " + @data.address.city, @default_text_settings.merge(size: 10, leading: 6)
+          @document.text_box @data.address.zip.to_s + " " + @data.address.city, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 10)
         end
       end
     end

--- a/apir/app/services/pdfs/generators/mail_header_generator.rb
+++ b/apir/app/services/pdfs/generators/mail_header_generator.rb
@@ -128,7 +128,8 @@ module Pdfs
       end
 
       def draw_recipient_address
-        @document.bounding_box([@document.bounds.width - 175, @document.bounds.height - @address_offset], width: 175, height: 100) do
+        # don't specify a height to ensure that everything lands on the same page
+        @document.bounding_box([@document.bounds.width - 175, @document.bounds.height - @address_offset], width: 175) do
           # @document.stroke_bounds
 
           @document.text @data.customer.company.name, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.company.present?

--- a/apir/app/services/pdfs/generators/mail_header_generator.rb
+++ b/apir/app/services/pdfs/generators/mail_header_generator.rb
@@ -131,15 +131,13 @@ module Pdfs
         @document.bounding_box([@document.bounds.width - 175, @document.bounds.height - @address_offset], width: 175, height: 100) do
           # @document.stroke_bounds
 
-          @document.text @data.customer.company.name, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.company
-          @document.text @data.customer.department, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.department
+          @document.text @data.customer.company.name, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.company.present?
+          @document.text @data.customer.department, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.department.present?
           @document.text (@data.customer.salutation || "") + " " + @data.customer.full_name, @default_text_settings.merge(size: 10, leading: 6)
           # use text_box to avoid line-wrapping long addresses
           @document.text_box @data.address.street, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 10)
-          @document.move_down(16)
-          if @data.address.supplement && @data.address.supplement.length > 0
-            @document.text @data.address.supplement, @default_text_settings.merge(size: 10, leading: 6)
-          end
+          @document.move_down 16
+          @document.text @data.address.supplement, @default_text_settings.merge(size: 10, leading: 6) if @data.address.supplement.present?
           @document.text_box @data.address.zip.to_s + " " + @data.address.city, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 10)
         end
       end


### PR DESCRIPTION
Fix #434.

Die Adresse erscheint nun immer vollständig auf der ersten Seite,
auch wenn diese aufgrund langer Firmennamen / Departemente mehr Zeilen benötigt.

Die alternative (font size kleiner machen, damit der Text jeweils auf eine Zeile passt) sah zu merkwürdig aus.