### PR TITLE
Fix #433

### DIFF
--- a/apir/app/services/pdfs/invoice_effort_report_pdf.rb
+++ b/apir/app/services/pdfs/invoice_effort_report_pdf.rb
@@ -7,5 +7,16 @@ module Pdfs
     def efforts_holder
       @data_holder.project
     end
+
+    def is_in_range?(date)
+      # only list efforts that happened in the time period of this invoice
+      date.between?(@data_holder.beginning, @data_holder.ending)
+    end
+
+    def effort_date_range(uniq_dates)
+      # match the dates specified in the invoice
+      # this is mainly relevant if uniq_dates is empty
+      [@data_holder.beginning, @data_holder.ending]
+    end
   end
 end

--- a/frontend/src/views/invoices/InvoiceForm.tsx
+++ b/frontend/src/views/invoices/InvoiceForm.tsx
@@ -96,7 +96,7 @@ export default class InvoiceForm extends React.Component<Props> {
                 color={'inherit'}
                 title={
                   invoice.project_id
-                    ? 'Aufwandsrapport drucken'
+                    ? 'Aufwandsrapport für diese Rechnung drucken'
                     : 'Da die Rechnung kein verlinktes Projekt hat, kann kein Aufwandrapport erzeugt werden.'
                 }
                 icon={StatisticsIcon}


### PR DESCRIPTION
Fix #433

Besides generating an effort report for the whole project, you can now also generate one for an invoice,
in which case the date and address of the invoice (and not the project) will be used.