### PR TITLE
Clean up VAT fields.

### DIFF
--- a/frontend/src/form/fields/CurrencyField.tsx
+++ b/frontend/src/form/fields/CurrencyField.tsx
@@ -6,6 +6,6 @@ const toString = (n: number) => (n / factor).toFixed(2);
 const toValue = (s: string) => Math.round(Number(s) * factor);
 
 const CurrencyField = (props: TransformingFieldProps<number>) => (
-  <TransformingField {...props} toString={toString} toValue={toValue} type={'number'} unit={'CHF'} />
+  <TransformingField disableUpDown {...props} toString={toString} toValue={toValue} type={'number'} unit={'CHF'} />
 );
 export default CurrencyField;

--- a/frontend/src/form/fields/PercentageField.tsx
+++ b/frontend/src/form/fields/PercentageField.tsx
@@ -2,10 +2,15 @@ import * as React from 'react';
 import { TransformingField, TransformingFieldProps } from './TransformingField';
 
 const factor = 100;
-const toString = (n: number) => (n * factor).toFixed(2);
+const toString = (digits: number) => (n: number) => (n * factor).toFixed(digits);
 const toValue = (s: string) => Number(s) / factor;
 
-const PercentageField = (props: TransformingFieldProps<number>) => (
-  <TransformingField disableUpDown {...props} toString={toString} toValue={toValue} type={'number'} unit={'%'} />
-);
+const PercentageField = (props: TransformingFieldProps<number> & {digits?: number}) => {
+  const {digits = 2, ...rest} = props;
+  return (
+    <TransformingField disableUpDown {...rest} toString={toString(digits)} toValue={toValue} type={'number'} unit={'%'} />
+  );
+};
+// vats only have 1 decimal digit
+export const VatField = (props: TransformingFieldProps<number>) => PercentageField({digits: 1, ...props});
 export default PercentageField;

--- a/frontend/src/form/fields/PercentageField.tsx
+++ b/frontend/src/form/fields/PercentageField.tsx
@@ -6,6 +6,6 @@ const toString = (n: number) => (n * factor).toFixed(2);
 const toValue = (s: string) => Number(s) / factor;
 
 const PercentageField = (props: TransformingFieldProps<number>) => (
-  <TransformingField {...props} toString={toString} toValue={toValue} type={'number'} unit={'%'} />
+  <TransformingField disableUpDown {...props} toString={toString} toValue={toValue} type={'number'} unit={'%'} />
 );
 export default PercentageField;

--- a/frontend/src/form/fields/TransformingField.tsx
+++ b/frontend/src/form/fields/TransformingField.tsx
@@ -1,14 +1,43 @@
+// tslint:disable:max-classes-per-file
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import * as React from 'react';
 import { DimeCustomFieldProps, DimeInputField } from './common';
 
+// for number fields: disable the +1/-1 buttons,
+// as they are rather silly for vats like 7.7
+// source: https://stackoverflow.com/questions/50823182/material-ui-remove-up-down-arrow-dials-from-textview
+const style = {
+  noUpDown: { /* Firefox */
+      '& input[type=number]': {
+      '-moz-appearance': 'textfield',
+    }, /* Chrome, Safari, Edge, Opera */
+      '& input[type=number]::-webkit-outer-spin-button': {
+      '-webkit-appearance': 'none',
+      'margin': 0,
+    },
+      '& input[type=number]::-webkit-inner-spin-button': {
+      '-webkit-appearance': 'none',
+      'margin': 0,
+    },
+  },
+};
+
 export type TransformingFieldProps<T> = DimeCustomFieldProps<T | null>;
 
-interface Props<T> extends TransformingFieldProps<T> {
+interface InnerProps<T> extends TransformingFieldProps<T> {
   toValue: (s: string) => T;
   toString: ((value: T) => string) | any; // FIXME weird type bug
 }
+// disabling +1/-1 buttonly only makes sense on number fields.
+interface GeneralProps<T> extends InnerProps<T> {
+  disableUpDown?: false;
+}
+interface NoUpDownProps extends InnerProps<number> {
+  disableUpDown: true;
+}
+type Props<T> = GeneralProps<T> | NoUpDownProps;
 
-export class TransformingField<T> extends React.Component<Props<T>> {
+class TransformingFieldInner<T> extends React.Component<InnerProps<T> & {className?: any} > {
 
   get format() {
     return this.props.value === null || this.props.value === undefined ? '' : this.props.toString(this.props.value);
@@ -18,7 +47,7 @@ export class TransformingField<T> extends React.Component<Props<T>> {
     focused: Boolean(false),
     representation: '',
   };
-  constructor(props: Props<T>) {
+  constructor(props: InnerProps<T>) {
     super(props);
     this.state.representation = this.format;
   }
@@ -61,6 +90,37 @@ export class TransformingField<T> extends React.Component<Props<T>> {
 
   render = () => {
     const { toValue, toString, ...rest } = this.props;
-    return <DimeInputField {...rest} value={this.value} onChange={this.handleChange} onBlur={this.handleBlur} onFocus={this.handleFocus} />;
+    return (
+      <DimeInputField
+        {...rest}
+        value={this.value}
+        onChange={this.handleChange}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
+      />
+    );
+  }
+}
+// 2021-10-29 This seems like way too much boilerplate.
+// Is there an easier way to specialize TransformingField<T> for T=number ?
+class TransformingNumberFieldInner extends React.Component<InnerProps<number> & WithStyles<typeof style> > {
+  render = () => {
+    const { classes, ...rest} = this.props;
+    return <TransformingFieldInner className={classes.noUpDown} {...rest} />;
+  }
+}
+const TransformingNumberFieldMiddle = withStyles(style)(TransformingNumberFieldInner);
+
+export class TransformingField<T> extends React.Component<Props<T> > {
+  render = () => {
+    if (this.props.disableUpDown) {
+      const props = this.props as NoUpDownProps;
+      const {disableUpDown, ...rest} = props;
+      return <TransformingNumberFieldMiddle {...rest} />;
+    } else {
+      const props = this.props as GeneralProps<T>;
+      const {disableUpDown, ...rest} = props;
+      return <TransformingFieldInner {...rest} />;
+    }
   }
 }

--- a/frontend/src/form/fields/common.tsx
+++ b/frontend/src/form/fields/common.tsx
@@ -42,6 +42,7 @@ interface DimeFieldProps extends SharedProps, FormikInjectableProps {
 export interface DimeInputFieldProps<T = string> extends DimeFieldProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   value: T;
+  className?: any;
 }
 
 export interface DimeCustomFieldProps<T, OutputValue = T> extends DimeFieldProps {

--- a/frontend/src/layout/DimeLayout.tsx
+++ b/frontend/src/layout/DimeLayout.tsx
@@ -15,7 +15,7 @@ import compose from '../utilities/compose';
 import { ChevronLeftIcon } from './icons';
 import { Navigation } from './Navigation';
 
-export const drawerWidth = 240;
+export const drawerWidth = 252;
 
 export const styles = (theme: Theme) =>
   createStyles({

--- a/frontend/src/views/invoices/InvoicePositionRenderer.tsx
+++ b/frontend/src/views/invoices/InvoicePositionRenderer.tsx
@@ -10,7 +10,7 @@ import { RateUnitSelect } from '../../form/entitySelect/RateUnitSelect';
 import { NumberField, TextField } from '../../form/fields/common';
 import CurrencyField from '../../form/fields/CurrencyField';
 import { DimeField } from '../../form/fields/formik';
-import PercentageField from '../../form/fields/PercentageField';
+import PercentageField, { VatField } from '../../form/fields/PercentageField';
 import {ActionButton} from '../../layout/ActionButton';
 import { ConfirmationButton } from '../../layout/ConfirmationDialog';
 import { DimeTableCell } from '../../layout/DimeTableCell';
@@ -123,7 +123,7 @@ export default class InvoicePositionRenderer extends React.Component<Props> {
                       <DimeField component={NumberField} name={name('amount')} margin={'none'} />
                     </DimeTableCell>
                     <DimeTableCell>
-                      <DimeField delayed component={PercentageField} name={name('vat')} margin={'none'} />
+                      <DimeField delayed component={VatField} name={name('vat')} margin={'none'} />
                     </DimeTableCell>
                     <DimeTableCell>{this.props.mainStore!.formatCurrency(total, false)}</DimeTableCell>
                     <DimeTableCell style={{paddingRight: '0px'}}>

--- a/frontend/src/views/offers/OfferPositionRenderer.tsx
+++ b/frontend/src/views/offers/OfferPositionRenderer.tsx
@@ -11,7 +11,7 @@ import { RateUnitSelect } from '../../form/entitySelect/RateUnitSelect';
 import { NumberField, TextField } from '../../form/fields/common';
 import CurrencyField from '../../form/fields/CurrencyField';
 import { DimeField } from '../../form/fields/formik';
-import PercentageField from '../../form/fields/PercentageField';
+import PercentageField, { VatField } from '../../form/fields/PercentageField';
 import {ActionButton} from '../../layout/ActionButton';
 import { ConfirmationButton } from '../../layout/ConfirmationDialog';
 import { DimeTableCell } from '../../layout/DimeTableCell';
@@ -151,7 +151,7 @@ export default class OfferPositionRenderer extends React.Component<Props> {
                       <DimeField component={NumberField} name={name('amount')} margin={'none'} disabled={disabled} />
                     </DimeTableCell>
                     <DimeTableCell>
-                      <DimeField delayed component={PercentageField} name={name('vat')} margin={'none'} disabled={disabled} />
+                      <DimeField delayed component={VatField} name={name('vat')} margin={'none'} disabled={disabled} />
                     </DimeTableCell>
                     <DimeTableCell>{this.props.mainStore!.formatCurrency(total, false)}</DimeTableCell>
                     <DimeTableCell style={{paddingRight: '0px'}}>

--- a/frontend/src/views/projects/ProjectPositionRenderer.tsx
+++ b/frontend/src/views/projects/ProjectPositionRenderer.tsx
@@ -11,7 +11,7 @@ import { RateUnitSelect } from '../../form/entitySelect/RateUnitSelect';
 import {TextField} from '../../form/fields/common';
 import CurrencyField from '../../form/fields/CurrencyField';
 import { DimeField } from '../../form/fields/formik';
-import PercentageField from '../../form/fields/PercentageField';
+import PercentageField, { VatField } from '../../form/fields/PercentageField';
 import {ActionButton} from '../../layout/ActionButton';
 import { ConfirmationButton } from '../../layout/ConfirmationDialog';
 import { DimeTableCell } from '../../layout/DimeTableCell';
@@ -132,7 +132,7 @@ export default class ProjectPositionRenderer extends React.Component<Props> {
                       )}
                     </DimeTableCell>
                     <DimeTableCell>
-                      <DimeField required delayed component={PercentageField} name={name('vat')} margin={'none'} />
+                      <DimeField required delayed component={VatField} name={name('vat')} margin={'none'} />
                     </DimeTableCell>
                     <DimeTableCell>
                       {p.efforts_value_with_unit}

--- a/frontend/src/views/reports/ProjectReport.tsx
+++ b/frontend/src/views/reports/ProjectReport.tsx
@@ -14,7 +14,7 @@ import { ProjectSelect } from '../../form/entitySelect/ProjectSelect';
 import {TextField} from '../../form/fields/common';
 import CurrencyField from '../../form/fields/CurrencyField';
 import { DimeField } from '../../form/fields/formik';
-import PercentageField from '../../form/fields/PercentageField';
+import PercentageField, { VatField } from '../../form/fields/PercentageField';
 import {FormikSubmitDetector} from '../../form/FormikSubmitDetector';
 import {ConfirmationButton} from '../../layout/ConfirmationDialog';
 import { DimeAppBar } from '../../layout/DimeAppBar';
@@ -150,7 +150,7 @@ export class ProjectReport extends React.Component<Props, State> {
                       <DimeField isMulti component={EmployeeSelect} name="exclude_employee_ids" label={'Exklusive Mitarbeiter'} />
                     </Grid>
                     <Grid item xs={12} md={2}>
-                      <DimeField component={PercentageField} name={'vat'} label={'MwSt.'} />
+                      <DimeField component={VatField} name={'vat'} label={'MwSt.'} />
                     </Grid>
                   </Grid>
 

--- a/frontend/src/views/services/ServiceForm.tsx
+++ b/frontend/src/views/services/ServiceForm.tsx
@@ -15,7 +15,7 @@ import { RateUnitSelect } from '../../form/entitySelect/RateUnitSelect';
 import { NumberField, SwitchField, TextField } from '../../form/fields/common';
 import CurrencyField from '../../form/fields/CurrencyField';
 import { DimeField } from '../../form/fields/formik';
-import PercentageField from '../../form/fields/PercentageField';
+import PercentageField, { VatField } from '../../form/fields/PercentageField';
 import { FormView, FormViewProps } from '../../form/FormView';
 import { DimePaper } from '../../layout/DimePaper';
 import { DimeTableCell } from '../../layout/DimeTableCell';
@@ -88,7 +88,7 @@ export default class ServiceForm extends React.Component<Props> {
                         <DimeField component={TextField} name={'description'} label={'Beschreibung'} />
                       </Grid>
                       <Grid item xs={12} lg={6}>
-                        <DimeField component={PercentageField} required name={'vat'} label={'Mehrwertsteuer'} />
+                        <DimeField component={VatField} required name={'vat'} label={'Mehrwertsteuer'} />
                       </Grid>
                       <Grid item xs={12} lg={6}>
                         <Grid item xs={12}>


### PR DESCRIPTION
- Remove +1/-1 buttons from vat fields and currency fields.
- Display only 1 decimal digit for VATs (to match what the backend actually stores).
- Adjust main css to avoid a mini scroll bar.
Fix #456