### PR TITLE
Fix QR-bill SPS compliance: split street + building number

### DIFF
--- a/apir/app/controllers/v2/companies_controller.rb
+++ b/apir/app/controllers/v2/companies_controller.rb
@@ -102,7 +102,7 @@ module V2
         :salutation,
         customer_tag_ids: [],
         phones_attributes: [:id, :number, :category, :customer_id],
-        addresses_attributes: [:id, :city, :country, :customer_id, :description, :zip, :street, :supplement, :hidden]
+        addresses_attributes: [:id, :city, :country, :customer_id, :description, :zip, :street, :street_number, :supplement, :hidden]
       )
     end
 

--- a/apir/app/controllers/v2/employees_controller.rb
+++ b/apir/app/controllers/v2/employees_controller.rb
@@ -122,7 +122,7 @@ module V2
         work_periods_attributes: [
           :id, :ending, :pensum, :beginning, :yearly_vacation_budget, :hourly_paid
         ],
-        addresses_attributes: [:id, :city, :country, :customer_id, :description, :zip, :street, :supplement, :hidden]
+        addresses_attributes: [:id, :city, :country, :customer_id, :description, :zip, :street, :street_number, :supplement, :hidden]
       )
     end
 

--- a/apir/app/controllers/v2/global_settings_controller.rb
+++ b/apir/app/controllers/v2/global_settings_controller.rb
@@ -23,8 +23,11 @@ module V2
     private
 
     def global_setting_params
-      params.require(:global_setting).permit(:id, :sender_name, :sender_street, :sender_zip, :sender_city, :sender_phone, :sender_mail, :sender_vat, :sender_bank, :sender_web, :service_order_comment, :sender_bank_detail, :sender_bank_iban,
-                                             :sender_bank_bic)
+      params.require(:global_setting).permit(
+        :id, :sender_name, :sender_street, :sender_street_number, :sender_zip, :sender_city,
+        :sender_phone, :sender_mail, :sender_vat, :sender_bank, :sender_web,
+        :service_order_comment, :sender_bank_detail, :sender_bank_iban, :sender_bank_bic
+      )
     end
   end
 end

--- a/apir/app/controllers/v2/people_controller.rb
+++ b/apir/app/controllers/v2/people_controller.rb
@@ -105,7 +105,7 @@ module V2
         :salutation,
         customer_tag_ids: [],
         phones_attributes: [:id, :number, :category, :customer_id],
-        addresses_attributes: [:id, :city, :country, :customer_id, :description, :zip, :street, :supplement, :hidden]
+        addresses_attributes: [:id, :city, :country, :customer_id, :description, :zip, :street, :street_number, :supplement, :hidden]
       )
     end
 

--- a/apir/app/decorators/customer_xlsx_decorator.rb
+++ b/apir/app/decorators/customer_xlsx_decorator.rb
@@ -14,7 +14,7 @@ class CustomerXlsxDecorator < ApplicationDecorator
   def addresses
     object.addresses.map do |address|
       [
-        [address.street, address.supplement].reject(&:blank?).join(" "),
+        [address.full_street, address.supplement].reject(&:blank?).join(" "),
         [address.zip, address.city].reject(&:blank?).join(" ")
       ]
     end

--- a/apir/app/models/address.rb
+++ b/apir/app/models/address.rb
@@ -17,6 +17,10 @@ class Address < ApplicationRecord
     self[:supplement] || ""
   end
 
+  def full_street
+    [street, street_number].compact_blank.join(" ")
+  end
+
   def self.params
     attribute_names.map(&:to_sym) - [:created_at, :updated_at, :deleted_at]
   end

--- a/apir/app/models/global_setting.rb
+++ b/apir/app/models/global_setting.rb
@@ -10,6 +10,10 @@ class GlobalSetting < ApplicationRecord
 
   validate :is_the_only_one
 
+  def full_sender_street
+    [sender_street, sender_street_number].compact_blank.join(" ")
+  end
+
   def is_the_only_one
     errors.add(:id, :unique, message: "There can only be one GlobalSetting, somehow you managed to create a new one.") if GlobalSetting.where.not(id: id).any?
   end

--- a/apir/app/services/pdfs/generators/mail_header_generator.rb
+++ b/apir/app/services/pdfs/generators/mail_header_generator.rb
@@ -97,7 +97,7 @@ module Pdfs
             # @document.stroke_bounds
 
             @document.transparent(0.5) do
-              @document.draw_text @global_setting.sender_street, @default_text_settings.merge(at: [0, 94])
+              @document.draw_text @global_setting.full_sender_street, @default_text_settings.merge(at: [0, 94])
               @document.draw_text "CH-#{@global_setting.sender_zip} #{@global_setting.sender_city}", @default_text_settings.merge(at: [0, 81])
               @document.fill_color "007DC2"
               @document.draw_text "T ", @default_text_settings.merge(at: [0, 68], style: :bold)
@@ -118,7 +118,7 @@ module Pdfs
           # @document.stroke_bounds
 
           @document.text @global_setting.sender_name, @default_text_settings.merge(size: 10, leading: 6)
-          @document.text @global_setting.sender_street, @default_text_settings.merge(size: 10, leading: 6)
+          @document.text @global_setting.full_sender_street, @default_text_settings.merge(size: 10, leading: 6)
           @document.text "#{@global_setting.sender_zip} #{@global_setting.sender_city}", @default_text_settings.merge(size: 10, leading: 6)
           @document.text @global_setting.sender_phone, @default_text_settings.merge(size: 10, leading: 6)
           @document.text @accountant.email, @default_text_settings.merge(size: 10, leading: 20) if @accountant&.email
@@ -135,7 +135,7 @@ module Pdfs
           @document.text @data.customer.department, @default_text_settings.merge(size: 10, leading: 6) if @data.customer.department.present?
           @document.text "#{@data.customer.salutation || ""} #{@data.customer.full_name}", @default_text_settings.merge(size: 10, leading: 6)
           # use text_box to avoid line-wrapping long addresses
-          @document.text_box @data.address.street, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 12)
+          @document.text_box @data.address.full_street, @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 12)
           @document.move_down 16
           @document.text @data.address.supplement, @default_text_settings.merge(size: 10, leading: 6) if @data.address.supplement.present?
           @document.text_box "#{@data.address.zip} #{@data.address.city}", @default_text_settings.merge(size: 10, leading: 6, overflow: :shrink_to_fit, at: [0, @document.cursor], height: 12)

--- a/apir/app/services/pdfs/invoice_esr_pdf.rb
+++ b/apir/app/services/pdfs/invoice_esr_pdf.rb
@@ -54,7 +54,7 @@ module Pdfs
         # stroke_bounds
 
         text @global_setting.sender_name, size: 9, style: :bold, character_spacing: @spacing
-        text @global_setting.sender_street, size: 10, character_spacing: @spacing
+        text @global_setting.full_sender_street, size: 10, character_spacing: @spacing
         text "#{@global_setting.sender_zip} #{@global_setting.sender_city}", size: 10, character_spacing: @spacing
       end
     end
@@ -71,7 +71,7 @@ module Pdfs
         move_down 5
         text @invoice.customer.company.name, size: font_size, character_spacing: @spacing, leading: leading if @invoice.customer.company
         text @invoice.customer.full_name, size: font_size, character_spacing: @spacing, leading: leading
-        text @invoice.address.street + supplement, size: font_size, character_spacing: @spacing, leading: leading
+        text @invoice.address.full_street + supplement, size: font_size, character_spacing: @spacing, leading: leading
         text "#{@invoice.address.zip} #{@invoice.address.city}", size: font_size, character_spacing: @spacing, leading: leading
       end
     end
@@ -112,7 +112,7 @@ module Pdfs
         # stroke_bounds
 
         text @global_setting.sender_name, size: 9, style: :bold, character_spacing: @spacing
-        text @global_setting.sender_street, size: 10, character_spacing: @spacing
+        text @global_setting.full_sender_street, size: 10, character_spacing: @spacing
         text "#{@global_setting.sender_zip} #{@global_setting.sender_city}", size: 10, character_spacing: @spacing
       end
     end
@@ -162,7 +162,7 @@ module Pdfs
         move_down 5
         text @invoice.customer.company.name, size: font_size, character_spacing: @spacing, leading: leading if @invoice.customer.company
         text @invoice.customer.full_name, size: font_size, character_spacing: @spacing, leading: leading
-        text @invoice.address.street + supplement, size: font_size, character_spacing: @spacing, leading: leading
+        text @invoice.address.full_street + supplement, size: font_size, character_spacing: @spacing, leading: leading
         text "#{@invoice.address.zip} #{@invoice.address.city}", size: font_size, character_spacing: @spacing, leading: leading
       end
     end
@@ -197,7 +197,7 @@ module Pdfs
           total_formated = format_money(total)
 
           text @global_setting.sender_bank_detail, size: info_size, character_spacing: @spacing, leading: leading
-          text "#{@global_setting.sender_name}, #{@global_setting.sender_street}, #{@global_setting.sender_zip} #{@global_setting.sender_city}", size: info_size, character_spacing: @spacing, leading: leading
+          text "#{@global_setting.sender_name}, #{@global_setting.full_sender_street}, #{@global_setting.sender_zip} #{@global_setting.sender_city}", size: info_size, character_spacing: @spacing, leading: leading
           text "#{I18n.t(:invoice_nr)} #{@invoice.id}", size: info_size, character_spacing: @spacing, leading: leading
           text @global_setting.sender_bank_iban, size: info_size, character_spacing: @spacing, leading: leading
           text @global_setting.sender_bank_bic, size: info_size, character_spacing: @spacing, leading: leading

--- a/apir/app/services/pdfs/invoice_qr_bill_pdf.rb
+++ b/apir/app/services/pdfs/invoice_qr_bill_pdf.rb
@@ -58,30 +58,34 @@ module Pdfs
       params[:qrcode_filepath]                                = "#{Dir.pwd}/tmp/qrcode-#{@invoice.id}.png"
       params[:output_params][:format]                         = "qrcode_png"
       params[:bill_params][:creditor][:iban]                  = @global_setting.sender_bank_iban
-      params[:bill_params][:creditor][:address][:type]        = "S"
-      params[:bill_params][:creditor][:address][:name]        = @global_setting.sender_name
-      params[:bill_params][:creditor][:address][:line1]       = @global_setting.sender_street
-      params[:bill_params][:creditor][:address][:postal_code] = @global_setting.sender_zip.to_s
-      params[:bill_params][:creditor][:address][:town]        = @global_setting.sender_city
-      params[:bill_params][:creditor][:address][:country]     = "CH"
-      params[:bill_params][:amount]                           = number_to_currency((@invoice.breakdown[:final_total] / 5.0).round * 5 / 100.0, unit: "", separator: ".", delimiter: "")
-      params[:bill_params][:currency]                         = "CHF"
-      params[:bill_params][:debtor][:address][:type]          = "S"
+      raise "QR-Bill requires a building number. Please update the address in settings and on the invoice." if @global_setting.sender_street_number.blank? || @invoice.address.street_number.blank?
+
+      params[:bill_params][:creditor][:address][:type]            = "S"
+      params[:bill_params][:creditor][:address][:name]            = @global_setting.sender_name
+      params[:bill_params][:creditor][:address][:street_name]     = @global_setting.sender_street
+      params[:bill_params][:creditor][:address][:building_number] = @global_setting.sender_street_number
+      params[:bill_params][:creditor][:address][:postal_code]     = @global_setting.sender_zip.to_s
+      params[:bill_params][:creditor][:address][:town]            = @global_setting.sender_city
+      params[:bill_params][:creditor][:address][:country]         = "CH"
+      params[:bill_params][:amount]                               = number_to_currency((@invoice.breakdown[:final_total] / 5.0).round * 5 / 100.0, unit: "", separator: ".", delimiter: "")
+      params[:bill_params][:currency]                             = "CHF"
+      params[:bill_params][:debtor][:address][:type]              = "S"
       if @invoice.customer.company
         printname = @invoice.customer.company.name
         printname.concat(", ")
         printname.concat(@invoice.customer.full_name)
-        params[:bill_params][:debtor][:address][:name]          = printname
+        params[:bill_params][:debtor][:address][:name]            = printname
       else
-        params[:bill_params][:debtor][:address][:name]          = @invoice.customer.full_name
+        params[:bill_params][:debtor][:address][:name]            = @invoice.customer.full_name
       end
-      params[:bill_params][:debtor][:address][:line1]         = @invoice.address.street
-      params[:bill_params][:debtor][:address][:postal_code]   = @invoice.address.zip.to_s
-      params[:bill_params][:debtor][:address][:town]          = @invoice.address.city
-      params[:bill_params][:debtor][:address][:country]       = get_country_abbr(@invoice.address.country)
+      params[:bill_params][:debtor][:address][:street_name]       = @invoice.address.street
+      params[:bill_params][:debtor][:address][:building_number]   = @invoice.address.street_number
+      params[:bill_params][:debtor][:address][:postal_code]       = @invoice.address.zip.to_s
+      params[:bill_params][:debtor][:address][:town]              = @invoice.address.city
+      params[:bill_params][:debtor][:address][:country]           = get_country_abbr(@invoice.address.country)
 
-      params[:bill_params][:reference_type]                   = "NON"
-      params[:bill_params][:additionally_information]         = I18n.t(:invoice_nr_esr) + @invoice.id.to_s
+      params[:bill_params][:reference_type]                       = "NON"
+      params[:bill_params][:additionally_information]             = I18n.t(:invoice_nr_esr) + @invoice.id.to_s
 
       @bill = QRBills.generate(params)
     end
@@ -113,7 +117,7 @@ module Pdfs
           text I18n.t(:payable_to), size: 6, style: :bold, leading: 3
           text @global_setting.sender_bank_iban, size: font_size, leading: leading
           text @global_setting.sender_name, size: font_size, leading: leading
-          text @global_setting.sender_street, size: font_size, leading: leading
+          text @global_setting.full_sender_street, size: font_size, leading: leading
           text "#{@global_setting.sender_zip} #{@global_setting.sender_city}", size: font_size, leading: leading
 
           move_down 9
@@ -126,7 +130,7 @@ module Pdfs
           else
             text @invoice.customer.full_name, size: font_size, leading: leading
           end
-          text @invoice.address.street + supplement, size: font_size, leading: leading
+          text @invoice.address.full_street + supplement, size: font_size, leading: leading
           text "#{@invoice.address.zip} #{@invoice.address.city}", size: font_size, leading: leading
           text @invoice.address.country, size: font_size, leading: leading
         end
@@ -187,7 +191,7 @@ module Pdfs
           text I18n.t(:payable_to), size: h_font_size, style: :bold, leading: h_leading
           text @global_setting.sender_bank_iban, size: font_size, leading: leading
           text @global_setting.sender_name, size: font_size, leading: leading
-          text @global_setting.sender_street, size: font_size, leading: leading
+          text @global_setting.full_sender_street, size: font_size, leading: leading
           text "#{@global_setting.sender_zip} #{@global_setting.sender_city}", size: font_size, leading: leading
 
           move_down 11
@@ -205,7 +209,7 @@ module Pdfs
           else
             text @invoice.customer.full_name, size: font_size, leading: leading
           end
-          text @invoice.address.street + supplement, size: font_size, leading: leading
+          text @invoice.address.full_street + supplement, size: font_size, leading: leading
           text "#{@invoice.address.zip} #{@invoice.address.city}", size: font_size, leading: leading
           text @invoice.address.country, size: font_size, leading: leading
         end
@@ -242,7 +246,7 @@ module Pdfs
           total_formated = format_money(total)
 
           text @global_setting.sender_bank_detail, size: info_size, character_spacing: @spacing, leading: leading
-          text "#{@global_setting.sender_name}, #{@global_setting.sender_street}, #{@global_setting.sender_zip} #{@global_setting.sender_city}", size: info_size, character_spacing: @spacing, leading: leading
+          text "#{@global_setting.sender_name}, #{@global_setting.full_sender_street}, #{@global_setting.sender_zip} #{@global_setting.sender_city}", size: info_size, character_spacing: @spacing, leading: leading
           text "#{I18n.t(:invoice_nr)} #{@invoice.id}", size: info_size, character_spacing: @spacing, leading: leading
           text @global_setting.sender_bank_iban, size: info_size, character_spacing: @spacing, leading: leading
           text @global_setting.sender_bank_bic, size: info_size, character_spacing: @spacing, leading: leading

--- a/apir/app/views/v2/companies/index.json.jbuilder
+++ b/apir/app/views/v2/companies/index.json.jbuilder
@@ -6,7 +6,7 @@ json.set! :data do
     json.extract! company.decorate, :id, :type, :comment, :company_id, :department, :department_in_address, :email, :first_name, :last_name, :hidden, :archived, :name, :accountant_id, :rate_group_id, :salutation, :created_at, :updated_at
     json.set! :addresses do
       json.array! company.addresses do |address|
-        json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :supplement, :created_at, :updated_at
+        json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :street_number, :supplement, :created_at, :updated_at
       end
     end
     json.set! :people do

--- a/apir/app/views/v2/companies/show.json.jbuilder
+++ b/apir/app/views/v2/companies/show.json.jbuilder
@@ -6,7 +6,7 @@ json.extract! @company, :id, :type, :comment, :company_id, :department, :departm
 
 json.set! :addresses do
   json.array! @company.addresses do |address|
-    json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :supplement, :created_at, :updated_at, :hidden
+    json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :street_number, :supplement, :created_at, :updated_at, :hidden
   end
 end
 

--- a/apir/app/views/v2/customers/show.json.jbuilder
+++ b/apir/app/views/v2/customers/show.json.jbuilder
@@ -10,7 +10,7 @@ end
 
 json.set! :addresses do
   json.array! @customer.all_addresses do |address|
-    json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :supplement, :created_at, :updated_at, :hidden
+    json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :street_number, :supplement, :created_at, :updated_at, :hidden
   end
 end
 

--- a/apir/app/views/v2/customers_import/verify.json.jbuilder
+++ b/apir/app/views/v2/customers_import/verify.json.jbuilder
@@ -11,5 +11,5 @@ json.array! @customers do |customer|
   json.set! :fax, customer.phones.find(&:fax?)&.number
   json.set! :rate_group_name, customer.rate_group&.name
   json.set! :customer_tag_name, customer.customer_tags&.first&.name
-  json.extract! customer.addresses.first, :street, :street_number, :supplement, :city, :supplement, :zip, :country, :description
+  json.extract! customer.addresses.first, :street, :street_number, :supplement, :city, :zip, :country, :description
 end

--- a/apir/app/views/v2/customers_import/verify.json.jbuilder
+++ b/apir/app/views/v2/customers_import/verify.json.jbuilder
@@ -11,5 +11,5 @@ json.array! @customers do |customer|
   json.set! :fax, customer.phones.find(&:fax?)&.number
   json.set! :rate_group_name, customer.rate_group&.name
   json.set! :customer_tag_name, customer.customer_tags&.first&.name
-  json.extract! customer.addresses.first, :street, :supplement, :city, :supplement, :zip, :country, :description
+  json.extract! customer.addresses.first, :street, :street_number, :supplement, :city, :supplement, :zip, :country, :description
 end

--- a/apir/app/views/v2/employees/show.json.jbuilder
+++ b/apir/app/views/v2/employees/show.json.jbuilder
@@ -17,6 +17,6 @@ end
 
 json.set! :addresses do
   json.array! @employee.addresses do |address|
-    json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :supplement, :created_at, :updated_at, :hidden
+    json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :street_number, :supplement, :created_at, :updated_at, :hidden
   end
 end

--- a/apir/app/views/v2/global_settings/index.json.jbuilder
+++ b/apir/app/views/v2/global_settings/index.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-json.extract! @global_setting, :id, :sender_name, :sender_street, :sender_zip, :sender_city, :sender_phone, :sender_mail, :sender_vat, :sender_bank, :sender_web, :created_at, :updated_at, :service_order_comment, :sender_bank_detail,
+json.extract! @global_setting, :id, :sender_name, :sender_street, :sender_street_number,
+              :sender_zip, :sender_city, :sender_phone, :sender_mail, :sender_vat, :sender_bank,
+              :sender_web, :created_at, :updated_at, :service_order_comment, :sender_bank_detail,
               :sender_bank_iban, :sender_bank_bic

--- a/apir/app/views/v2/global_settings/show.json.jbuilder
+++ b/apir/app/views/v2/global_settings/show.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-json.extract! @global_setting, :id, :sender_name, :sender_street, :sender_zip, :sender_city, :sender_phone, :sender_mail, :sender_vat, :sender_bank, :sender_web, :created_at, :updated_at, :service_order_comment, :sender_bank_detail,
+json.extract! @global_setting, :id, :sender_name, :sender_street, :sender_street_number,
+              :sender_zip, :sender_city, :sender_phone, :sender_mail, :sender_vat, :sender_bank,
+              :sender_web, :created_at, :updated_at, :service_order_comment, :sender_bank_detail,
               :sender_bank_iban, :sender_bank_bic

--- a/apir/app/views/v2/people/show.json.jbuilder
+++ b/apir/app/views/v2/people/show.json.jbuilder
@@ -9,7 +9,7 @@ end
 
 json.set! :addresses do
   json.array! @person.addresses do |address|
-    json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :supplement, :hidden, :created_at, :updated_at
+    json.extract! address, :id, :city, :country, :customer_id, :description, :zip, :street, :street_number, :supplement, :hidden, :created_at, :updated_at
   end
 end
 

--- a/apir/db/migrate/20260713000000_add_street_number_to_addresses_and_global_settings.rb
+++ b/apir/db/migrate/20260713000000_add_street_number_to_addresses_and_global_settings.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddStreetNumberToAddressesAndGlobalSettings < ActiveRecord::Migration[8.0]
+  def up
+    add_column :addresses, :street_number, :string, null: true
+    add_column :global_settings, :sender_street_number, :string, null: true
+
+    Address.find_each do |a|
+      m = a.street.match(/\A(.*?)\s+(\d[\w]*)\z/)
+      a.update_columns(street: m[1], street_number: m[2]) if m
+    end
+
+    GlobalSetting.find_each do |gs|
+      m = gs.sender_street.match(/\A(.*?)\s+(\d[\w]*)\z/)
+      gs.update_columns(sender_street: m[1], sender_street_number: m[2]) if m
+    end
+  end
+
+  def down
+    Address.find_each do |a|
+      a.update_columns(street: [a.street, a.street_number].compact.join(" "))
+    end
+
+    GlobalSetting.find_each do |gs|
+      gs.update_columns(sender_street: [gs.sender_street, gs.sender_street_number].compact.join(" "))
+    end
+
+    remove_column :addresses, :street_number
+    remove_column :global_settings, :sender_street_number
+  end
+end

--- a/apir/db/schema.rb
+++ b/apir/db/schema.rb
@@ -2,17 +2,16 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_14_193505) do
-
-  create_table "addresses", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+ActiveRecord::Schema[8.0].define(version: 2026_07_13_000000) do
+  create_table "addresses", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "city", null: false
     t.string "country"
     t.integer "customer_id", unsigned: true
@@ -28,11 +27,12 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.integer "deleted_by"
     t.boolean "hidden", default: false, null: false
     t.integer "employee_id", unsigned: true
+    t.string "street_number"
     t.index ["customer_id"], name: "addresses_customer_id_foreign"
     t.index ["employee_id"], name: "fk_rails_1c4d4ea1f4"
   end
 
-  create_table "costgroups", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "costgroups", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "number", null: false, unsigned: true
     t.string "name", null: false
     t.timestamp "deleted_at"
@@ -41,12 +41,12 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["number"], name: "costgroups_number_unique", unique: true
   end
 
-  create_table "customer_taggable", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "customer_taggable", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "customer_tag_id", null: false
     t.integer "customer_id", null: false
   end
 
-  create_table "customer_tags", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "customer_tags", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.boolean "archived", default: false, null: false
     t.string "name", null: false
     t.timestamp "created_at"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.integer "deleted_by"
   end
 
-  create_table "customers", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "customers", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.text "comment"
     t.integer "company_id", unsigned: true
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["rate_group_id"], name: "customers_rate_group_id_foreign"
   end
 
-  create_table "employee_groups", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "employee_groups", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.timestamp "created_at"
     t.timestamp "updated_at"
@@ -93,7 +93,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.integer "deleted_by"
   end
 
-  create_table "employee_settings", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "employee_settings", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "employee_id", unsigned: true
     t.timestamp "deleted_at"
     t.timestamp "created_at"
@@ -101,7 +101,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["employee_id"], name: "employee_settings_employee_id_unique", unique: true
   end
 
-  create_table "employees", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "employees", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.string "encrypted_password", limit: 60, null: false
     t.boolean "is_admin", default: false, null: false
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["employee_group_id"], name: "employees_employee_group_id_foreign"
   end
 
-  create_table "global_settings", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "global_settings", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "sender_name", default: "Example Company", null: false
     t.string "sender_street", default: "Test street 1", null: false
     t.string "sender_zip", default: "1234", null: false
@@ -136,9 +136,10 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.string "sender_bank_detail", default: "Example Bank, 0000 Example", null: false
     t.string "sender_bank_iban", default: "CH00 0000 0000 0000 0000 0", null: false
     t.string "sender_bank_bic", default: "EXABANK00000", null: false
+    t.string "sender_street_number"
   end
 
-  create_table "holidays", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "holidays", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.date "date", null: false
     t.integer "duration", null: false
@@ -150,7 +151,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.integer "deleted_by"
   end
 
-  create_table "invoice_costgroup_distributions", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "invoice_costgroup_distributions", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "costgroup_number", unsigned: true
     t.integer "invoice_id", null: false, unsigned: true
     t.integer "weight", null: false
@@ -164,7 +165,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["invoice_id"], name: "invoice_costgroup_distributions_invoice_id_foreign"
   end
 
-  create_table "invoice_discounts", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "invoice_discounts", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "invoice_id", unsigned: true
     t.string "name", null: false
     t.boolean "percentage", default: false, null: false
@@ -178,7 +179,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["invoice_id"], name: "invoice_discounts_invoice_id_foreign"
   end
 
-  create_table "invoice_positions", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "invoice_positions", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.decimal "amount", precision: 8, scale: 2, null: false
     t.string "description", null: false
     t.integer "invoice_id", unsigned: true
@@ -200,7 +201,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["rate_unit_id"], name: "invoice_positions_rate_unit_id_foreign"
   end
 
-  create_table "invoices", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "invoices", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "accountant_id", unsigned: true
     t.integer "customer_id", unsigned: true
     t.integer "address_id", unsigned: true
@@ -224,37 +225,37 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["project_id"], name: "invoices_project_id_foreign"
   end
 
-  create_table "locations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "locations", charset: "utf8mb3", force: :cascade do |t|
     t.boolean "archived", null: false
     t.integer "order", default: 9999, null: false
     t.string "name", null: false
     t.string "url", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "migrations", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "migrations", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "migration", null: false
     t.integer "batch", null: false
   end
 
-  create_table "offer_category_distributions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "offer_category_distributions", charset: "utf8mb3", force: :cascade do |t|
     t.integer "category_id", null: false, unsigned: true
     t.integer "weight", default: 100, null: false
     t.integer "offer_id", null: false, unsigned: true
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.timestamp "deleted_at"
     t.index ["category_id"], name: "fk_rails_6c9b6a4033"
     t.index ["offer_id"], name: "fk_rails_462bd91ec2"
   end
 
-  create_table "offer_costgroup_distributions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "offer_costgroup_distributions", charset: "utf8mb3", force: :cascade do |t|
     t.integer "costgroup_number", null: false, unsigned: true
     t.integer "weight", default: 100, null: false
     t.integer "offer_id", null: false, unsigned: true
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.timestamp "deleted_at"
     t.integer "created_by"
     t.integer "updated_by"
@@ -263,7 +264,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["offer_id"], name: "fk_rails_fab8c874f8"
   end
 
-  create_table "offer_discounts", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "offer_discounts", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "offer_id", null: false, unsigned: true
     t.boolean "percentage", default: false, null: false
@@ -277,7 +278,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["offer_id"], name: "offer_discounts_offer_id_foreign"
   end
 
-  create_table "offer_positions", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "offer_positions", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.decimal "amount", precision: 8, scale: 2, null: false
     t.string "description"
     t.integer "offer_id", null: false, unsigned: true
@@ -299,7 +300,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["service_id"], name: "offer_positions_service_id_foreign"
   end
 
-  create_table "offers", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "offers", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "accountant_id", unsigned: true
     t.integer "customer_id", unsigned: true
     t.integer "address_id", unsigned: true
@@ -323,7 +324,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["rate_group_id"], name: "offers_rate_group_id_foreign"
   end
 
-  create_table "phones", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "phones", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "category", null: false
     t.integer "customer_id", null: false, unsigned: true
     t.string "number", null: false
@@ -336,7 +337,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["customer_id"], name: "phones_customer_id_foreign"
   end
 
-  create_table "position_groups", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "position_groups", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.timestamp "deleted_at"
     t.timestamp "created_at"
@@ -348,7 +349,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.integer "order"
   end
 
-  create_table "project_categories", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "project_categories", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.boolean "archived", default: false, null: false
     t.string "name", null: false
     t.timestamp "deleted_at"
@@ -359,19 +360,19 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.integer "deleted_by"
   end
 
-  create_table "project_category_distributions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "project_category_distributions", charset: "utf8mb3", force: :cascade do |t|
     t.integer "category_id", null: false, unsigned: true
     t.integer "weight", default: 100, null: false
     t.integer "project_id", null: false, unsigned: true
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at", precision: nil
     t.index ["category_id"], name: "fk_rails_c9f8aca5e7"
     t.index ["deleted_at"], name: "index_project_category_distributions_on_deleted_at"
     t.index ["project_id"], name: "fk_rails_dfe1a93a72"
   end
 
-  create_table "project_comment_presets", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "project_comment_presets", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "comment_preset", limit: 200, null: false
     t.timestamp "deleted_at"
     t.timestamp "created_at"
@@ -382,7 +383,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["comment_preset"], name: "project_comment_presets_comment_preset_unique", unique: true
   end
 
-  create_table "project_comments", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "project_comments", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "comment", null: false
     t.date "date", null: false
     t.integer "project_id", unsigned: true
@@ -395,7 +396,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["project_id"], name: "project_comments_project_id_foreign"
   end
 
-  create_table "project_costgroup_distributions", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "project_costgroup_distributions", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "costgroup_number", unsigned: true
     t.integer "project_id", null: false, unsigned: true
     t.integer "weight"
@@ -409,7 +410,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["project_id"], name: "project_costgroup_distributions_project_id_foreign"
   end
 
-  create_table "project_efforts", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "project_efforts", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.date "date", null: false
     t.integer "employee_id", unsigned: true
     t.integer "position_id", unsigned: true
@@ -426,7 +427,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["position_id"], name: "project_efforts_position_id_foreign"
   end
 
-  create_table "project_positions", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "project_positions", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "description"
     t.integer "price_per_rate", null: false
     t.integer "project_id", unsigned: true
@@ -447,7 +448,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["service_id"], name: "project_positions_service_id_foreign"
   end
 
-  create_table "projects", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "projects", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "accountant_id", unsigned: true
     t.integer "customer_id", unsigned: true
     t.integer "address_id", unsigned: true
@@ -474,12 +475,12 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["rate_group_id"], name: "projects_rate_group_id_foreign"
   end
 
-  create_table "rate_groups", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "rate_groups", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
   end
 
-  create_table "rate_units", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "rate_units", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "billing_unit", null: false
     t.string "effort_unit"
     t.decimal "factor", precision: 4, default: "1", null: false
@@ -494,19 +495,19 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.integer "deleted_by"
   end
 
-  create_table "service_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "service_categories", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "parent_category_id"
     t.string "name", null: false
     t.integer "number", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at", precision: nil
     t.string "french_name", null: false
     t.index ["deleted_at"], name: "index_service_categories_on_deleted_at"
     t.index ["parent_category_id"], name: "index_service_categories_on_parent_category_id"
   end
 
-  create_table "service_rates", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "service_rates", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "rate_group_id", null: false, unsigned: true
     t.integer "service_id", null: false, unsigned: true
     t.integer "rate_unit_id", null: false, unsigned: true
@@ -522,7 +523,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["service_id", "rate_group_id"], name: "service_rates_service_id_rate_group_id_unique", unique: true
   end
 
-  create_table "services", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "services", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.decimal "vat", precision: 4, scale: 3, null: false
@@ -539,7 +540,7 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.index ["service_category_id"], name: "index_services_on_service_category_id"
   end
 
-  create_table "versions", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "versions", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "item_type", limit: 191, null: false
     t.bigint "item_id", null: false
     t.string "event", null: false
@@ -548,17 +549,17 @@ ActiveRecord::Schema.define(version: 2024_02_14_193505) do
     t.timestamp "created_at"
   end
 
-  create_table "whitelisted_jwts", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "whitelisted_jwts", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "jti", null: false
     t.string "aud"
-    t.datetime "exp", null: false
+    t.datetime "exp", precision: nil, null: false
     t.integer "employee_id", unsigned: true
     t.timestamp "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.timestamp "updated_at"
     t.index ["employee_id"], name: "whitelisted_jwts_employee_id_foreign"
   end
 
-  create_table "work_periods", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "work_periods", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "employee_id", null: false, unsigned: true
     t.date "ending", null: false
     t.integer "pensum", null: false

--- a/apir/doc/openapi.yaml
+++ b/apir/doc/openapi.yaml
@@ -668,7 +668,7 @@ paths:
           type: integer
       responses:
         '200':
-          description: returns a customer
+          description: returns a customer with nullable fields null
           content:
             application/json:
               schema:
@@ -682,6 +682,7 @@ paths:
                     type: string
                   company_id:
                     type: integer
+                    nullable: true
                   department:
                     type: string
                   department_in_address:
@@ -700,6 +701,7 @@ paths:
                     nullable: true
                   accountant_id:
                     type: integer
+                    nullable: true
                   rate_group_id:
                     type: integer
                   salutation:
@@ -778,6 +780,7 @@ paths:
                           type: integer
                         description:
                           type: string
+                          nullable: true
                         zip:
                           type: integer
                         street:
@@ -851,7 +854,6 @@ paths:
                 - salutation
                 - created_at
                 - updated_at
-                - company
                 - addresses
                 - phone_numbers
                 - tags
@@ -1116,7 +1118,7 @@ paths:
           type: integer
       responses:
         '200':
-          description: returns an employee
+          description: returns an employee with nullable fields null
           content:
             application/json:
               schema:
@@ -1295,7 +1297,7 @@ paths:
       - V2::GlobalSetting
       responses:
         '200':
-          description: returns global settings
+          description: returns global settings with nullable fields null
           content:
             application/json:
               schema:
@@ -3365,6 +3367,7 @@ paths:
                           type: integer
                         description:
                           type: string
+                          nullable: true
                         zip:
                           type: integer
                         street:

--- a/apir/doc/openapi.yaml
+++ b/apir/doc/openapi.yaml
@@ -105,6 +105,8 @@ paths:
                                 type: string
                               updated_at:
                                 type: string
+                              street_number:
+                                type: string
                             required:
                             - id
                             - city
@@ -370,6 +372,8 @@ paths:
                           type: string
                         hidden:
                           type: boolean
+                        street_number:
+                          type: string
                       required:
                       - id
                       - city
@@ -784,6 +788,8 @@ paths:
                           type: string
                         hidden:
                           type: boolean
+                        street_number:
+                          type: string
                       required:
                       - id
                       - city
@@ -1246,6 +1252,8 @@ paths:
                           type: string
                         hidden:
                           type: boolean
+                        street_number:
+                          type: string
                       required:
                       - id
                       - city
@@ -1320,6 +1328,8 @@ paths:
                   sender_bank_iban:
                     type: string
                   sender_bank_bic:
+                    type: string
+                  sender_street_number:
                     type: string
                 required:
                 - id
@@ -3361,6 +3371,8 @@ paths:
                         created_at:
                           type: string
                         updated_at:
+                          type: string
+                        street_number:
                           type: string
                       required:
                       - id

--- a/apir/doc/openapi.yaml
+++ b/apir/doc/openapi.yaml
@@ -107,6 +107,7 @@ paths:
                                 type: string
                               street_number:
                                 type: string
+                                nullable: true
                             required:
                             - id
                             - city
@@ -374,6 +375,7 @@ paths:
                           type: boolean
                         street_number:
                           type: string
+                          nullable: true
                       required:
                       - id
                       - city
@@ -790,6 +792,7 @@ paths:
                           type: boolean
                         street_number:
                           type: string
+                          nullable: true
                       required:
                       - id
                       - city
@@ -1254,6 +1257,7 @@ paths:
                           type: boolean
                         street_number:
                           type: string
+                          nullable: true
                       required:
                       - id
                       - city
@@ -1331,6 +1335,7 @@ paths:
                     type: string
                   sender_street_number:
                     type: string
+                    nullable: true
                 required:
                 - id
                 - sender_name
@@ -3374,6 +3379,7 @@ paths:
                           type: string
                         street_number:
                           type: string
+                          nullable: true
                       required:
                       - id
                       - city

--- a/apir/spec/factories/addresses.rb
+++ b/apir/spec/factories/addresses.rb
@@ -6,7 +6,8 @@ FactoryBot.define do
     country { "Schweiz" }
     description { nil }
     zip { 8400 }
-    street { "Bahnhofstrasse 12" }
+    street { "Bahnhofstrasse" }
+    street_number { "12" }
     supplement { "Postfach 1230" }
     association :customer, factory: :person
 

--- a/apir/spec/factories/global_settings.rb
+++ b/apir/spec/factories/global_settings.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :global_setting do
     sender_name { "MyString" }
     sender_street { "MyString" }
+    sender_street_number { "1" }
     sender_zip { 8080 }
     sender_phone { "MyString" }
     sender_city { "MyString" }

--- a/apir/spec/requests/companies_spec.rb
+++ b/apir/spec/requests/companies_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "V2::Companies", type: :request do
 
     it "returns a company with nullable fields null" do
       company = create(:company)
-      create(:address, :with_company_customer, customer: company, description: nil)
+      create(:address, :with_company_customer, customer: company, description: nil, street_number: nil)
       get "/v2/companies/#{company.id}"
       expect(response).to have_http_status(:ok)
     end

--- a/apir/spec/requests/customers_spec.rb
+++ b/apir/spec/requests/customers_spec.rb
@@ -28,5 +28,12 @@ RSpec.describe "V2::Customers", type: :request do
       get "/v2/customers/#{customer.id}"
       expect(response).to have_http_status(:ok)
     end
+
+    it "returns a customer with nullable fields null" do
+      customer = create(:person, company: nil, accountant: nil)
+      create(:address, customer: customer, street_number: nil)
+      get "/v2/customers/#{customer.id}"
+      expect(response).to have_http_status(:ok)
+    end
   end
 end

--- a/apir/spec/requests/employees_spec.rb
+++ b/apir/spec/requests/employees_spec.rb
@@ -25,5 +25,12 @@ RSpec.describe "V2::Employees", type: :request do
       get "/v2/employees/#{target.id}"
       expect(response).to have_http_status(:ok)
     end
+
+    it "returns an employee with nullable fields null" do
+      target = create(:employee)
+      create(:address, employee: target, customer: nil, street_number: nil)
+      get "/v2/employees/#{target.id}"
+      expect(response).to have_http_status(:ok)
+    end
   end
 end

--- a/apir/spec/requests/global_settings_spec.rb
+++ b/apir/spec/requests/global_settings_spec.rb
@@ -15,5 +15,11 @@ RSpec.describe "V2::GlobalSettings", type: :request do
       get "/v2/global_settings"
       expect(response).to have_http_status(:ok)
     end
+
+    it "returns global settings with nullable fields null" do
+      create(:global_setting, sender_street_number: nil)
+      get "/v2/global_settings"
+      expect(response).to have_http_status(:ok)
+    end
   end
 end

--- a/apir/spec/requests/people_spec.rb
+++ b/apir/spec/requests/people_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "V2::People", type: :request do
 
     it "returns a person with nullable fields null" do
       person = create(:person, company: nil, accountant: nil)
+      create(:address, customer: person, street_number: nil)
       get "/v2/people/#{person.id}"
       expect(response).to have_http_status(:ok)
     end

--- a/frontend/src/form/entitySelect/AddressSelect.tsx
+++ b/frontend/src/form/entitySelect/AddressSelect.tsx
@@ -30,7 +30,7 @@ export class AddressSelect extends React.Component<Props> {
         .filter(a => this.props.value === a.id || !a.hidden)
         .map((a: Address) => ({
           value: a.id,
-          label: [a.street, a.supplement, a.zip, a.city, a.country].filter(x => Boolean(x)).join(', '),
+          label: [[a.street, a.street_number].filter(Boolean).join(' '), a.supplement, a.zip, a.city, a.country].filter(x => Boolean(x)).join(', '),
         }))
       : [];
   }

--- a/frontend/src/locales/messages.de.json
+++ b/frontend/src/locales/messages.de.json
@@ -326,6 +326,7 @@
   "view.offer.update.update_offer": "Offerte bearbeiten",
 
   "view.person.addresses_subform_inline.street": "Strasse",
+  "view.person.addresses_subform_inline.street_number": "Hausnr.",
   "view.person.addresses_subform_inline.supplement": "Addresszusatz",
   "view.person.addresses_subform_inline.zip": "PLZ",
   "view.person.addresses_subform_inline.city": "Stadt",

--- a/frontend/src/locales/messages.fr.json
+++ b/frontend/src/locales/messages.fr.json
@@ -325,6 +325,7 @@
   "view.offer.update.update_offer": "Modifier une offre",
 
   "view.person.addresses_subform_inline.street": "Rue",
+  "view.person.addresses_subform_inline.street_number": "No de bâtiment",
   "view.person.addresses_subform_inline.supplement": "Complément d'adresse",
   "view.person.addresses_subform_inline.zip": "Code Postal",
   "view.person.addresses_subform_inline.city": "Ville",

--- a/frontend/src/stores/globalSettingStore.ts
+++ b/frontend/src/stores/globalSettingStore.ts
@@ -5,7 +5,7 @@ import { MainStore } from './mainStore';
 export interface GlobalSettings {
   sender_name: string;
   sender_street: string;
-  sender_street_number: string;
+  sender_street_number: string | null;
   sender_zip: string;
   sender_city: string;
   sender_phone: string;

--- a/frontend/src/stores/globalSettingStore.ts
+++ b/frontend/src/stores/globalSettingStore.ts
@@ -5,6 +5,7 @@ import { MainStore } from './mainStore';
 export interface GlobalSettings {
   sender_name: string;
   sender_street: string;
+  sender_street_number: string;
   sender_zip: string;
   sender_city: string;
   sender_phone: string;

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -68,6 +68,7 @@ export interface paths {
                                     supplement: string;
                                     created_at: string;
                                     updated_at: string;
+                                    street_number?: string;
                                 }[];
                                 people: {
                                     id: number;
@@ -184,6 +185,7 @@ export interface paths {
                                 created_at: string;
                                 updated_at: string;
                                 hidden: boolean;
+                                street_number?: string;
                             }[];
                             phone_numbers: {
                                 id: number;
@@ -480,6 +482,7 @@ export interface paths {
                                 created_at: string;
                                 updated_at: string;
                                 hidden: boolean;
+                                street_number?: string;
                             }[];
                             phone_numbers: {
                                 id: number;
@@ -801,6 +804,7 @@ export interface paths {
                                 created_at: string;
                                 updated_at: string;
                                 hidden: boolean;
+                                street_number?: string;
                             }[];
                         };
                     };
@@ -855,6 +859,7 @@ export interface paths {
                             sender_bank_detail: string;
                             sender_bank_iban: string;
                             sender_bank_bic: string;
+                            sender_street_number?: string;
                         };
                     };
                 };
@@ -1903,6 +1908,7 @@ export interface paths {
                                 hidden: boolean;
                                 created_at: string;
                                 updated_at: string;
+                                street_number?: string;
                             }[];
                             phone_numbers: {
                                 id: number;

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -427,7 +427,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description returns a customer */
+                /** @description returns a customer with nullable fields null */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -437,7 +437,7 @@ export interface paths {
                             id: number;
                             type: string;
                             comment: string;
-                            company_id: number;
+                            company_id: number | null;
                             department: string;
                             department_in_address: boolean;
                             email: string;
@@ -446,12 +446,12 @@ export interface paths {
                             hidden: boolean;
                             archived: boolean;
                             name: unknown;
-                            accountant_id: number;
+                            accountant_id: number | null;
                             rate_group_id: number;
                             salutation: string;
                             created_at: string;
                             updated_at: string;
-                            company: {
+                            company?: {
                                 id: number;
                                 type: string;
                                 comment: string;
@@ -475,7 +475,7 @@ export interface paths {
                                 city: string;
                                 country: string;
                                 customer_id: number;
-                                description: string;
+                                description: string | null;
                                 zip: number;
                                 street: string;
                                 supplement: string;
@@ -739,7 +739,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description returns an employee */
+                /** @description returns an employee with nullable fields null */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -836,7 +836,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description returns global settings */
+                /** @description returns global settings with nullable fields null */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -1901,7 +1901,7 @@ export interface paths {
                                 city: string;
                                 country: string;
                                 customer_id: number;
-                                description: string;
+                                description: string | null;
                                 zip: number;
                                 street: string;
                                 supplement: string;

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -68,7 +68,7 @@ export interface paths {
                                     supplement: string;
                                     created_at: string;
                                     updated_at: string;
-                                    street_number?: string;
+                                    street_number?: string | null;
                                 }[];
                                 people: {
                                     id: number;
@@ -185,7 +185,7 @@ export interface paths {
                                 created_at: string;
                                 updated_at: string;
                                 hidden: boolean;
-                                street_number?: string;
+                                street_number?: string | null;
                             }[];
                             phone_numbers: {
                                 id: number;
@@ -482,7 +482,7 @@ export interface paths {
                                 created_at: string;
                                 updated_at: string;
                                 hidden: boolean;
-                                street_number?: string;
+                                street_number?: string | null;
                             }[];
                             phone_numbers: {
                                 id: number;
@@ -804,7 +804,7 @@ export interface paths {
                                 created_at: string;
                                 updated_at: string;
                                 hidden: boolean;
-                                street_number?: string;
+                                street_number?: string | null;
                             }[];
                         };
                     };
@@ -859,7 +859,7 @@ export interface paths {
                             sender_bank_detail: string;
                             sender_bank_iban: string;
                             sender_bank_bic: string;
-                            sender_street_number?: string;
+                            sender_street_number?: string | null;
                         };
                     };
                 };
@@ -1908,7 +1908,7 @@ export interface paths {
                                 hidden: boolean;
                                 created_at: string;
                                 updated_at: string;
-                                street_number?: string;
+                                street_number?: string | null;
                             }[];
                             phone_numbers: {
                                 id: number;

--- a/frontend/src/views/GlobalSettingsUpdate.tsx
+++ b/frontend/src/views/GlobalSettingsUpdate.tsx
@@ -27,6 +27,7 @@ const settingsSchema = localizeSchema(() =>
   yup.object({
     sender_name: yup.string().required(),
     sender_street: yup.string().required(),
+    sender_street_number: yup.string().nullable(true),
     sender_zip: yup.string().required(),
     sender_city: yup.string().required(),
     sender_phone: yup.string().required(),
@@ -75,6 +76,7 @@ export class GlobalSettingsUpdate extends React.Component<Props> {
                       <FormHeader>Dokumente</FormHeader>
                       <DimeField required component={TextField} name={'sender_name'} label={'Name'} />
                       <DimeField required component={TextField} name={'sender_street'} label={'Strasse'} />
+                      <DimeField component={TextField} name={'sender_street_number'} label={'Hausnr.'} />
                       <DimeField required component={TextField} name={'sender_zip'} label={'PLZ'} />
                       <DimeField required component={TextField} name={'sender_city'} label={'Ort'} />
                       <DimeField required component={TextField} name={'sender_phone'} label={'Telefon'} />

--- a/frontend/src/views/companies/CompanyForm.tsx
+++ b/frontend/src/views/companies/CompanyForm.tsx
@@ -88,7 +88,8 @@ export default class CompanyForm extends React.Component<Props> {
         id: '_',
         label: intlText('street'),
         format: (p: Person) => {
-          return <>{p.addresses ? (p.addresses.length > 0 ? p.addresses[0].street : '') : ''}</>;
+          const a = p.addresses && p.addresses.length > 0 ? p.addresses[0] : null;
+          return <>{a ? [a.street, a.street_number].filter(Boolean).join(' ') : ''}</>;
         },
       },
     ];

--- a/frontend/src/views/companies/CompanyOverview.tsx
+++ b/frontend/src/views/companies/CompanyOverview.tsx
@@ -40,7 +40,10 @@ export default class CompanyOverview extends React.Component<Props> {
         id: 'street',
         noSort: true,
         label: intlText('street'),
-        format: c => <>{c.addresses ? (c.addresses.length > 0 ? c.addresses[0].street : '') : ''}</>,
+        format: c => {
+          const a = c.addresses && c.addresses.length > 0 ? c.addresses[0] : null;
+          return <>{a ? [a.street, a.street_number].filter(Boolean).join(' ') : ''}</>;
+        },
       },
       {
         id: 'zip',

--- a/frontend/src/views/companies/companySchema.ts
+++ b/frontend/src/views/companies/companySchema.ts
@@ -18,6 +18,7 @@ export const companySchema = localizeSchema(() =>
           .required()
           .min(1000, 'general.schema.plz_digits'),
         street: yup.string().required(),
+        street_number: yup.string().nullable(true),
         supplement: yup.string().nullable(true),
       }),
     ),

--- a/frontend/src/views/employees/employeeSchema.tsx
+++ b/frontend/src/views/employees/employeeSchema.tsx
@@ -64,6 +64,7 @@ export const newEmployeeSchema = localizeSchema(() =>
           .required()
           .min(1000, 'general.schema.plz_digits'),
         street: yup.string().required(),
+        street_number: yup.string().nullable(true),
         supplement: yup.string().nullable(true),
       }),
     ),

--- a/frontend/src/views/persons/AddressesSubformInline.tsx
+++ b/frontend/src/views/persons/AddressesSubformInline.tsx
@@ -25,6 +25,7 @@ const template = () => ({
   formikKey: Math.random(),
   zip: 0,
   street: '',
+  street_number: '',
   hidden: false,
   supplement: '',
 });
@@ -64,8 +65,9 @@ export default class AddressesSubformInline extends React.Component<Props> {
             <Table size="small" style={{ minWidth: '1000px' }}>
               <TableHead>
                 <TableRow>
-                  <DimeTableCell style={{ width: '20%' }}> <FormattedMessage id={idPrefix + '.street'} /> </DimeTableCell>
-                  <DimeTableCell style={{ width: '15%' }}> <FormattedMessage id={idPrefix + '.supplement'} /> </DimeTableCell>
+                  <DimeTableCell style={{ width: '15%' }}> <FormattedMessage id={idPrefix + '.street'} /> </DimeTableCell>
+                  <DimeTableCell style={{ width: '8%' }}> <FormattedMessage id={idPrefix + '.street_number'} /> </DimeTableCell>
+                  <DimeTableCell style={{ width: '12%' }}> <FormattedMessage id={idPrefix + '.supplement'} /> </DimeTableCell>
                   <DimeTableCell style={{ width: '10%' }}> <FormattedMessage id={idPrefix + '.zip'} /> </DimeTableCell>
                   <DimeTableCell style={{ width: '15%' }}> <FormattedMessage id={idPrefix + '.city'} /> </DimeTableCell>
                   <DimeTableCell style={{ width: '15%' }}> <FormattedMessage id={idPrefix + '.country'} /> </DimeTableCell>
@@ -78,6 +80,7 @@ export default class AddressesSubformInline extends React.Component<Props> {
                 {inherited.map((a: Address) => (
                   <TableRow key={a.id}>
                     <DimeTableCell>{a.street}</DimeTableCell>
+                    <DimeTableCell>{a.street_number}</DimeTableCell>
                     <DimeTableCell>{a.supplement}</DimeTableCell>
                     <DimeTableCell>{a.zip}</DimeTableCell>
                     <DimeTableCell>{a.city}</DimeTableCell>
@@ -93,6 +96,9 @@ export default class AddressesSubformInline extends React.Component<Props> {
                     <TableRow key={a.id || a.formikKey}>
                       <DimeTableCell>
                         <DimeField delayed component={TextField} name={name('street')} margin={'none'} />
+                      </DimeTableCell>
+                      <DimeTableCell>
+                        <DimeField delayed component={TextField} name={name('street_number')} margin={'none'} />
                       </DimeTableCell>
                       <DimeTableCell>
                         <DimeField delayed component={TextField} name={name('supplement')} margin={'none'} />

--- a/frontend/src/views/persons/personSchema.ts
+++ b/frontend/src/views/persons/personSchema.ts
@@ -19,6 +19,7 @@ export const personSchema = localizeSchema(() =>
           .required()
           .min(1000, 'general.schema.plz_digits'),
         street: yup.string().required(),
+        street_number: yup.string().nullable(true),
         supplement: yup.string().nullable(true),
       }),
     ),


### PR DESCRIPTION
## Summary

- The `qr-bills` gem v2.0.0 removed K-type address support entirely. The existing code was passing `:line1` (a dead key), so QR bill generation was already silently non-compliant with the Swiss Payment Standard.
- Adds `street_number` to `addresses` and `sender_street_number` to `global_settings` via a migration that best-effort-splits existing combined values (e.g. "Bahnhofstrasse 42" → name "Bahnhofstrasse" + number "42"). Rows where the regex doesn't match keep `street_number = nil` and need manual cleanup post-deploy.
- Uses the correct type "S" gem keys (`street_name` / `building_number`) and raises a clear error if a building number is missing at PDF generation time.

## What changed

**Backend**
- Migration: `add_street_number_to_addresses_and_global_settings`
- `Address#full_street` / `GlobalSetting#full_sender_street` helpers for display
- All jbuilder views, controller permit lists, and the OpenAPI schema updated
- `invoice_qr_bill_pdf.rb`: correct gem keys, guard for missing building number
- `invoice_esr_pdf.rb`, `mail_header_generator.rb`, `customer_xlsx_decorator.rb`: use `full_street` helpers

**Frontend**
- `AddressesSubformInline` (shared by persons/companies/employees): new "Hausnr." column
- `GlobalSettingsUpdate`: new `sender_street_number` field
- Yup schemas, `GlobalSettings` store interface, `AddressSelect` label, company overview/form street display — all updated

## Test plan

- [ ] Run `bundle exec rspec` inside Docker — all 639 examples pass, coverage ≥ 92%
- [ ] Generate a QR-bill PDF for an invoice and confirm the QR code payload contains separate street name and building number
- [ ] Confirm that an address with no building number raises the guard error rather than producing a non-compliant QR code
- [ ] Open a person/company/employee address form and verify the new "Hausnr." column appears and saves correctly
- [ ] Open global settings and verify `sender_street_number` saves and reloads
- [ ] CI passes (OpenAPI diff clean, TypeScript diff clean, RuboCop clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate `street_number` for addresses and `sender_street_number` for global sender addresses.
  * Address forms, selectors, and company/employee/person views now support displaying and editing street numbers.
* **Improvements**
  * PDFs (invoices, mail headers, and QR bills) now render complete street lines including street numbers.
  * QR bill generation now requires street numbers to be present.
  * Existing data is migrated by splitting stored street text into street + number.
* **Documentation**
  * Updated API responses, OpenAPI schema, and generated frontend types for the new fields.
* **Localization**
  * Added German and French field labels for street number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->